### PR TITLE
Fix Multi-Arch duplicate field

### DIFF
--- a/crossbuilder
+++ b/crossbuilder
@@ -438,10 +438,10 @@ install_foreign () {
     do
         echo "Installing $dep"
         exec_container "mkdir -p foreign && cd foreign && apt-get download $dep && dpkg-deb -R $dep* tmp"
-        if ! exec_container "grep -qio '^Multi-arch: foreign' foreign/tmp/DEBIAN/control" ; then
-            exec_container "echo 'Multi-arch: foreign' >> foreign/tmp/DEBIAN/control"
-            exec_container "cd foreign && dpkg-deb -b tmp $dep*"
-        fi
+        exec_container "grep -vi '^multi' foreign/tmp/DEBIAN/control > foreign/tmp/DEBIAN/control.tmp"
+        exec_container "mv foreign/tmp/DEBIAN/control.tmp foreign/tmp/DEBIAN/control"
+	exec_container "echo 'Multi-Arch: foreign' >> foreign/tmp/DEBIAN/control"
+        exec_container "cd foreign && dpkg-deb -b tmp $dep*"
         exec_container_root "dpkg -i $SOURCE_PATH_CONTAINER/foreign/$dep*"
         exec_container "rm -r foreign/"
     done

--- a/crossbuilder
+++ b/crossbuilder
@@ -438,7 +438,7 @@ install_foreign () {
     do
         echo "Installing $dep"
         exec_container "mkdir -p foreign && cd foreign && apt-get download $dep && dpkg-deb -R $dep* tmp"
-        if ! exec_container "grep -q '^Multi-arch: foreign' foreign/tmp/DEBIAN/control" ; then
+        if ! exec_container "grep -qio '^Multi-arch: foreign' foreign/tmp/DEBIAN/control" ; then
             exec_container "echo 'Multi-arch: foreign' >> foreign/tmp/DEBIAN/control"
             exec_container "cd foreign && dpkg-deb -b tmp $dep*"
         fi


### PR DESCRIPTION
Previously I got this:
```
dpkg-deb: error: parsing file 'tmp/DEBIAN/control' near line 21 package 'dh-systemd':
 duplicate value for 'Multi-Arch' field
```
The script was not aware of the case of the letters of ```Multi-arch```.