### PR TITLE
ensure_upstream_tarball: support multiple tarball

### DIFF
--- a/crossbuilder
+++ b/crossbuilder
@@ -462,10 +462,12 @@ apply_build_profiles_to_debian_control () {
 
 ensure_upstream_tarball () {
     if [ -f ubports.source_location ]; then
-        SOURCE_URL=$(cat ubports.source_location | awk 'BEGIN{ RS = "" ; FS = "\n" }{print $1}')
-        TARGET_FILE=$(cat ubports.source_location | awk 'BEGIN{ RS = "" ; FS = "\n" }{print $2}')
-        echo "${POSITIVE_COLOR}Downloading upstream source tarball of $PACKAGE in container to $TARGET_FILE.${NC}"
-        exec_container "cd $USERDIR && wget --continue -O $TARGET_FILE $SOURCE_URL"
+        while read -r SOURCE_URL && read -r TARGET_FILE; do
+            echo "${POSITIVE_COLOR}Downloading upstream source tarball of $PACKAGE in container to $TARGET_FILE.${NC}"
+            # /dev/null redirection is required. Otherwise, `lxc exec` will closes stdin (i.e. the file).
+            # https://github.com/lxc/lxd/issues/2200
+            exec_container "cd $USERDIR && wget --continue -O $TARGET_FILE $SOURCE_URL" </dev/null
+        done <ubports.source_location
     elif grep quilt debian/source/format > /dev/null 2>&1 ; then
         echo "${POSITIVE_COLOR}Downloading upstream tarball of $PACKAGE in container.${NC}"
         enable_overlay_source


### PR DESCRIPTION
The same technique is used on build-tools' build-source.sh to support
multiple tarball. Thus, if this script can pull the upstream tarball(s),
CI would be able to pull them.

Sees https://github.com/ubports/build-tools/commit/47279578ce3602d3843a14835d5dc074bd6c8504