### PR TITLE
create_container: set CROSS_COMPILE env

### DIFF
--- a/crossbuilder
+++ b/crossbuilder
@@ -335,6 +335,7 @@ create_container () {
     fi
     exec_container_root "printf 'export PKG_CONFIG_PATH=/usr/lib/$TARGET_FARCH/pkgconfig\n\
 export QT_SELECT=qt5-$QT_SELECT_ARCH\n\
+export CROSS_COMPILE=$TARGET_FARCH-\n\
 export CC=$TARGET_FARCH-gcc\n\
 export CXX=$TARGET_FARCH-g++\n\
 ' >> /etc/profile.d/clickvars.sh"


### PR DESCRIPTION
This allows packages using bare makefiles to call strip and a few other
tools directly.