### PR TITLE
Make it possible to cross-build for focal

### DIFF
--- a/crossbuilder
+++ b/crossbuilder
@@ -108,7 +108,7 @@ variables () {
     fi
     DEBS_TARBALL="$DEBS_TARBALL_ROOT"_"$NEW_PACKAGE_VERSION.tar"
 
-    LXD_IMAGE_NO_DOT=$(echo $LXD_IMAGE | sed "s/\./-/")
+    LXD_IMAGE_NO_DOT=$(echo $LXD_IMAGE | sed "s|[./]|-|g")
     LXD_IMAGE_NO_PREFIX=$(echo $LXD_IMAGE_NO_DOT | sed "s/.*\://")
     LXD_IMAGE_NO_SDK=$(echo $LXD_IMAGE_NO_PREFIX | sed "s/ubuntu-sdk/usdk/")
     LXD_CONTAINER_COMPAT=builder-$PACKAGE-$LXD_IMAGE_NO_PREFIX

--- a/crossbuilder
+++ b/crossbuilder
@@ -296,6 +296,55 @@ start_container () {
     fi
 }
 
+nonsdk_container_setup () {
+    case "$TARGET_UBUNTU" in
+        16.04) ubports_repo_line="deb http://repo.ubports.com/ xenial main" ;;
+        18.04) ubports_repo_line="deb http://repo2.ubports.com/ bionic main" ;;
+        20.04) ubports_repo_line="deb http://repo2.ubports.com/ focal main" ;;
+    esac
+    if [ -n "$ubports_repo_line" ]; then
+        exec_container_root "echo '$ubports_repo_line' >/etc/apt/sources.list.d/ubports.list"
+    fi
+
+    # Skip multiarch setup if not crossbuilding
+    if [ "$HOST_ARCH" = "$TARGET_ARCH" ]; then
+        return
+    fi
+
+    exec_container_root "dpkg --add-architecture $TARGET_ARCH"
+
+    # i386 and amd64 archive is on http://archive.ubuntu.com/ubuntu/, while
+    # other architectures' are on http://ports.ubuntu.com/ubuntu-ports/. Some
+    # special handling for APT sources is needed.
+    case "${HOST_ARCH}-${TARGET_ARCH}" in
+        i386-amd64|amd64-i386)
+            # Both on archive, do nothing.
+            ;;
+        i386-*|amd64-*)
+            # Host is on archive, target is on ports.
+            exec_container_root "sed -E \
+                -e 's:(archive|security)\.ubuntu\.com/ubuntu/:ports.ubuntu.com/ubuntu-ports/:' \
+                -e 's:^deb :deb [arch=${TARGET_ARCH}] :' \
+                /etc/apt/sources.list >/etc/apt/sources.list.d/ports.list"
+            exec_container_root "sed -i -E \
+                -e 's:^deb :deb [arch=${HOST_ARCH}] :' \
+                /etc/apt/sources.list"
+        ;;
+        *-i386|*-amd64)
+            # Host is on ports, target is on archive.
+            exec_container_root "sed -E \
+                -e 's:ports\.ubuntu\.com/ubuntu-ports/ ([a-z]+)-security :security.ubuntu.com/ubuntu/ \1-security :' \
+                -e 's:ports\.ubuntu\.com/ubuntu-ports/ ([a-z-]+):archive.ubuntu.com/ubuntu/ \1 :' \
+                -e 's:^deb :deb [arch=${TARGET_ARCH}] :' \
+                /etc/apt/sources.list >/etc/apt/sources.list.d/non-ports.list"
+            exec_container_root "sed -i -E \
+                -e 's:^deb :deb [arch=${HOST_ARCH}] :' \
+                /etc/apt/sources.list"
+        ;;
+        # Not matched: both on ports, do nothing.
+    esac
+}
+
 create_container () {
     lxc remote --protocol=simplestreams --public=true --accept-certificate=true add ubports-sdk https://sdk-images.ubports.com || true
     lxc init $LXD_IMAGE $LXD_CONTAINER $EPHEMERAL_FLAG
@@ -324,6 +373,9 @@ create_container () {
         exec_container_root "add-apt-repository 'deb http://repo.ubports.com vivid main' >> /etc/apt/sources.list"
     fi
     wget -qO - "https://repo.ubports.com/keyring.gpg" | exec_container_root apt-key add -
+    if ! echo "$LXD_IMAGE" | grep -q "ubuntu-sdk"; then
+        nonsdk_container_setup
+    fi
     exec_container_root apt update
     exec_container_root apt install -y sudo debhelper ccache software-properties-common devscripts equivs qemu-user-static
     exec_container_root adduser $USERNAME sudo

--- a/crossbuilder
+++ b/crossbuilder
@@ -114,6 +114,10 @@ variables () {
     LXD_CONTAINER_COMPAT=builder-$PACKAGE-$LXD_IMAGE_NO_PREFIX
     LXD_CONTAINER=$PACKAGE-$LXD_IMAGE_NO_SDK
     LXD_CONTAINER=$(echo $LXD_CONTAINER | sed "s/\./-/")
+    if ! echo "$LXD_CONTAINER" | grep -q "${HOST_ARCH}-${TARGET_ARCH}"; then
+        # Using non-sdk image, needs to append arch ourselve
+        LXD_CONTAINER="${LXD_CONTAINER}-${HOST_ARCH}-${TARGET_ARCH}"
+    fi
     if lxc info $LXD_CONTAINER_COMPAT > /dev/null 2>&1 ; then
         echo "${ERROR_COLOR}Containers are switching to shorter names, please manually delete your container: lxc delete -f $LXD_CONTAINER_COMPAT${NC}"
         echo "${ERROR_COLOR}Next time it will be called $LXD_CONTAINER.${NC}"

--- a/crossbuilder
+++ b/crossbuilder
@@ -323,7 +323,7 @@ create_container () {
         exec_container_root "add-apt-repository -y ppa:ubports-developers/overlay"
         exec_container_root "add-apt-repository 'deb http://repo.ubports.com vivid main' >> /etc/apt/sources.list"
     fi
-    wget -qO - "http://repo.ubports.com/keyring.gpg" | exec_container_root apt-key add -
+    wget -qO - "https://repo.ubports.com/keyring.gpg" | exec_container_root apt-key add -
     exec_container_root apt update
     exec_container_root apt install -y sudo debhelper ccache software-properties-common devscripts equivs qemu-user-static
     exec_container_root adduser $USERNAME sudo

--- a/crossbuilder
+++ b/crossbuilder
@@ -321,9 +321,7 @@ create_container () {
     fi
     wget -qO - "http://repo.ubports.com/keyring.gpg" | exec_container_root apt-key add -
     exec_container_root apt update
-    exec_container_root apt install -y \
-        sudo debhelper ccache software-properties-common devscripts equivs \
-        qemu-user-static pkg-create-dbgsym
+    exec_container_root apt install -y sudo debhelper ccache software-properties-common devscripts equivs qemu-user-static
     exec_container_root adduser $USERNAME sudo
     # set empty password for the user
     exec_container_root passwd --delete $USERNAME
@@ -547,7 +545,6 @@ build_deb () {
     echo "${POSITIVE_COLOR}Packing build artifacts in $DEBS_TARBALL.${NC}"
     rm -f $DEBS_TARBALL_ROOT*
     exec_container "tar cf ../$DEBS_TARBALL ../*.deb"
-    exec_container "tar rf ../$DEBS_TARBALL ../*.ddeb || true"
     lxc file pull $LXD_CONTAINER$USERDIR/$DEBS_TARBALL .
 }
 


### PR DESCRIPTION
This PR contains a set of commits that allow me (and other people) to cross-build packages using the Focal base image and UBports' repository. This helps a lot when porting Ubuntu Touch to Ubuntu 20.04.

To cross-build for Ubuntu 20.04, one simply has to `--lxd-image=ubuntu:20.04` (along with the architecture). Crossbuilder will setup the container automatically.

This PR also contains an unrelated commit to switch GPG keyring downloading to HTTPS. Because it will conflict with another commit in this PR, I think it's easier to just include it in this PR.