### PR TITLE
nonsdk_container_setup: fix ubuntu version detection

### DIFF
--- a/crossbuilder
+++ b/crossbuilder
@@ -297,10 +297,11 @@ start_container () {
 }
 
 nonsdk_container_setup () {
-    case "$TARGET_UBUNTU" in
-        16.04) ubports_repo_line="deb http://repo.ubports.com/ xenial main" ;;
-        18.04) ubports_repo_line="deb http://repo2.ubports.com/ bionic main" ;;
-        20.04) ubports_repo_line="deb http://repo2.ubports.com/ focal main" ;;
+    container_ubuntu_version=$(exec_container_root "lsb_release -cs")
+
+    case "$container_ubuntu_version" in
+        xenial|bionic) ubports_repo_line="deb http://repo.ubports.com/ $container_ubuntu_version main" ;;
+        focal) ubports_repo_line="deb http://repo2.ubports.com/ $container_ubuntu_version main" ;;
     esac
     if [ -n "$ubports_repo_line" ]; then
         exec_container_root "echo '$ubports_repo_line' >/etc/apt/sources.list.d/ubports.list"


### PR DESCRIPTION
TARGET_UBUNTU is a command-line option intended to help choosing the lxd
image. If we specify our own image, this variable becomes useless.
Instead, run `lsb_release` in the container to get image's Ubuntu
version.

Also re-route bionic to repo instead of repo2. It's available there, and
repo should contains more packages as it allows packages that Aptly
(repo2) otherwise doesn't.