### PR TITLE
Use Bash as the intepreter

### DIFF
--- a/crossbuilder
+++ b/crossbuilder
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2016 Canonical Ltd.
 #


### PR DESCRIPTION
Well, '-e' is not defined in /bin/sh. With it, every (colored) text
printed has '-e' prefix. Use /bin/bash instead.