### PR TITLE
Deploy via ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,35 @@ Crossbuilder aims at making cross compiling code and deploying projects to devic
 Initially developed in: https://launchpad.net/crossbuilder
 
 To use it, clone the repository and just run it from there:
-
-    cd crossbuilder
-    ./crossbuilder help
+```bash
+cd crossbuilder
+./crossbuilder help
+```
 
 To build and deploy your project on the device connected to your computer all in one go:
-
-    cd yourproject/
-    crossbuilder
+```bash
+cd yourproject/
+crossbuilder
+```
 
 Change a line of code and type crossbuilder again to re-build and re-deploy.
 
 To go even faster, bypass building Debian packages with:
-
-    crossbuilder --no-deb
+```bash
+crossbuilder --no-deb
+```
 
 For an even faster LXD setup, resetup LXD using ZFS:
-
-    crossbuilder setup-lxd
+```bash
+crossbuilder setup-lxd
+```
 
 To enter the LXD container used to build:
+```bash
+crossbuilder shell
+```
 
-    crossbuilder shell
+To use ssh instead of adb to deploy, use the ```--ssh``` option. If your device has ssh enabled on address let's say 192.168.0.5, use:
+```bash
+crossbuilder --ssh=phablet@192.168.0.5
+```

--- a/crossbuilder
+++ b/crossbuilder
@@ -91,6 +91,15 @@ push_device () {
     adb push "$@"
 }
 
+check_file_exists_device () {
+    if ! adb pull "$1" /tmp 2>&1 >/dev/null ; then
+        return 1
+    fi
+
+    rm -f "/tmp/$(basename $1)"
+    return 0
+}
+
 exec_container_root () {
     command="$@"
     #echo lxc exec $LXD_CONTAINER "$@"
@@ -800,7 +809,7 @@ deploy_deb () {
         check_for_device_network
         echo -e "${POSITIVE_COLOR}Upgrading packages already installed on device with newly built ones.${NC}"
         # create local deb repository on device
-        if ! adb pull /tmp/repo/$CREATE_REPO_SCRIPT 2> /dev/null ; then
+        if ! check_file_exists_device /tmp/repo/$CREATE_REPO_SCRIPT ; then
             push_device $SCRIPT_DIR/$CREATE_REPO_SCRIPT /tmp/repo/
             exec_device /tmp/repo/$CREATE_REPO_SCRIPT /tmp/repo
             exec_device "printf 'deb file:/tmp/repo/ /\n' > /tmp/repo/sources.list"
@@ -810,7 +819,6 @@ deploy_deb () {
             exec_device "printf 'Package: *\nPin: release o=local\nPin-Priority: 2000\n\nPackage: *\nPin: release a=$SERIES*\nPin-Priority: 50' | SUDO_ASKPASS=/tmp/askpass.sh sudo -A tee /etc/apt/preferences.d/localrepo.pref"
 #            exec_device SUDO_ASKPASS=/tmp/askpass.sh sudo -A apt-get update
         else
-            rm -f $CREATE_REPO_SCRIPT
             exec_device /tmp/repo/$CREATE_REPO_SCRIPT /tmp/repo
         fi;
 
@@ -854,8 +862,7 @@ deploy_to_device () {
 
     # check password is correct
     exec_device SUDO_ASKPASS=/tmp/askpass.sh sudo -A touch /tmp/password_ok
-    if adb pull /tmp/password_ok ; then
-        rm -f password_ok
+    if check_file_exists_device /tmp/password_ok ; then
         exec_device SUDO_ASKPASS=/tmp/askpass.sh sudo -A rm -f /tmp/password_ok
     else
         echo -e "${ERROR_COLOR}Device password incorrect. Use --password to pass the correct one or write it in $DEVICE_PASSWORD_FILE.${NC}"

--- a/crossbuilder
+++ b/crossbuilder
@@ -86,6 +86,11 @@ exec_device () {
     adb shell "$@"
 }
 
+push_device () {
+    #echo adb push "$@"
+    adb push "$@"
+}
+
 exec_container_root () {
     command="$@"
     #echo lxc exec $LXD_CONTAINER "$@"
@@ -780,7 +785,7 @@ deploy_deb () {
     echo -e "${POSITIVE_COLOR}Transferring Debian packages to device.${NC}"
     # tranfer debian packages to device
     exec_device mkdir -p /tmp/repo
-    adb push $DEBS_TARBALL /tmp/repo/
+    push_device $DEBS_TARBALL /tmp/repo/
     exec_device "cd /tmp/repo && tar xvf /tmp/repo/$DEBS_TARBALL && rm -f /tmp/repo/$DEBS_TARBALL_ROOT*"
 
     # install debian packages on device
@@ -797,7 +802,7 @@ deploy_deb () {
         # create local deb repository on device
         rm -f $CREATE_REPO_SCRIPT
         if ! adb pull /tmp/repo/$CREATE_REPO_SCRIPT 2> /dev/null ; then
-            adb push $SCRIPT_DIR/$CREATE_REPO_SCRIPT /tmp/repo/
+            push_device $SCRIPT_DIR/$CREATE_REPO_SCRIPT /tmp/repo/
             exec_device /tmp/repo/$CREATE_REPO_SCRIPT /tmp/repo
             exec_device "printf 'deb file:/tmp/repo/ /\n' > /tmp/repo/sources.list"
             exec_device "cp /etc/apt/sources.list /tmp/repo/all.list"
@@ -868,7 +873,7 @@ deploy_to_device () {
     # execute post deploy
     if test -e $SOURCE_PATH_LOCAL/$POST_DEPLOY_SCRIPT ; then
         echo -e "${POSITIVE_COLOR}Execute project specific post deploy script ($POST_DEPLOY_SCRIPT).${NC}"
-        adb push $SOURCE_PATH_LOCAL/$POST_DEPLOY_SCRIPT /tmp
+        push_device $SOURCE_PATH_LOCAL/$POST_DEPLOY_SCRIPT /tmp
         exec_device sh /tmp/$(basename $POST_DEPLOY_SCRIPT)
     else
         echo -e "${POSITIVE_COLOR}If a script named $POST_DEPLOY_SCRIPT existed, it would be executed on device after every deploy.${NC}"

--- a/crossbuilder
+++ b/crossbuilder
@@ -78,20 +78,36 @@ display_help () {
     echo "  --no-deb         - Do not build Debian packages and uses rsync to deploy the build artifacts."
     echo "  --deploy-path    - When deploying with --no-deb (rsync), installation path for the build artifacts [defaults to /]."
     echo "  --parallel       - Set parallelism of the build. Defaults to the number of logical core + 1."
+    echo "  --ssh            - Use ssh with provided address instead of adb."
 }
 
 
 exec_device () {
-    #echo adb shell "$@"
+    if [ ! -z "$SSH_ADDRESS" ] ; then 
+        ssh -o "ConnectTimeout=5" "$SSH_ADDRESS" "$@" || true
+        return
+    fi
+
     adb shell "$@"
 }
 
 push_device () {
-    #echo adb push "$@"
+    if [ ! -z "$SSH_ADDRESS" ] ; then 
+        local last="${!#}"
+        local argv=( "${@:1:$#-1}" )
+        scp ${argv[@]} "$SSH_ADDRESS:$last"
+        return
+    fi
+
     adb push "$@"
 }
 
 check_file_exists_device () {
+    if [ ! -z "$SSH_ADDRESS" ] ; then 
+        ssh -o "ConnectTimeout=5" -q "$SSH_ADDRESS" '[ -e "'$1'" ]'
+        return
+    fi
+
     if ! adb pull "$1" /tmp 2>&1 >/dev/null ; then
         # Some pull error, so we can assume, that the file doesn't exist.
         return 1
@@ -102,6 +118,11 @@ check_file_exists_device () {
 }
 
 check_device_accessible () {
+    if [ ! -z "$SSH_ADDRESS" ] ; then 
+        ssh -o "ConnectTimeout=5" -q "$SSH_ADDRESS" "exit"
+        return
+    fi
+
     local DEVICE_STATE=$(adb get-state 2>/dev/null || true)
     if [ "$DEVICE_STATE" = "device" ] ; then
         # Device found
@@ -966,6 +987,9 @@ while [ "$1" != "" ]; do
             --parallel)
                 PARALLEL_BUILD=$VALUE
             ;;
+            --ssh)
+                SSH_ADDRESS=$VALUE
+            ;;
             --help)
                 display_help
                 exit 0
@@ -996,13 +1020,24 @@ if [ "$COMMAND" = "help" ] ; then
 fi
 
 MISSING_PACKAGES=
-if ! which adb > /dev/null 2>&1 ; then
-    if which apt > /dev/null 2>&1 ; then
-        MISSING_PACKAGES="android-tools-adb $MISSING_PACKAGES"
-    elif which pacman > /dev/null 2>&1 ; then
-        MISSING_PACKAGES="android-tools $MISSING_PACKAGES"
+if [ -z "$SSH_ADDRESS" ] ; then
+    if ! which adb > /dev/null 2>&1 ; then
+        if which apt > /dev/null 2>&1 ; then
+            MISSING_PACKAGES="android-tools-adb $MISSING_PACKAGES"
+        elif which pacman > /dev/null 2>&1 ; then
+            MISSING_PACKAGES="android-tools $MISSING_PACKAGES"
+        fi
+    fi
+else
+    if ! which ssh > /dev/null 2>&1 || ! which scp > /dev/null 2>&1 ; then
+        if which apt > /dev/null 2>&1 ; then
+            MISSING_PACKAGES="openssh-client $MISSING_PACKAGES"
+        elif which pacman > /dev/null 2>&1 ; then
+            MISSING_PACKAGES="openssh $MISSING_PACKAGES"
+        fi
     fi
 fi
+
 if ! which jq > /dev/null; then
     MISSING_PACKAGES="jq $MISSING_PACKAGES"
 fi
@@ -1086,7 +1121,7 @@ if check_device_accessible ; then
         DETECTED_TARGET_UBUNTU=$(exec_device "lsb_release --release --short" | tr -d '\r')
         DEPLOY=true
     fi
-fi;
+fi
 
 TARGET_ARCH="${TARGET_ARCH:-${DETECTED_TARGET_ARCH:-armhf}}"
 TARGET_UBUNTU="${TARGET_UBUNTU:-${DETECTED_TARGET_UBUNTU:-16.04}}"

--- a/crossbuilder
+++ b/crossbuilder
@@ -800,7 +800,6 @@ deploy_deb () {
         check_for_device_network
         echo -e "${POSITIVE_COLOR}Upgrading packages already installed on device with newly built ones.${NC}"
         # create local deb repository on device
-        rm -f $CREATE_REPO_SCRIPT
         if ! adb pull /tmp/repo/$CREATE_REPO_SCRIPT 2> /dev/null ; then
             push_device $SCRIPT_DIR/$CREATE_REPO_SCRIPT /tmp/repo/
             exec_device /tmp/repo/$CREATE_REPO_SCRIPT /tmp/repo
@@ -811,6 +810,7 @@ deploy_deb () {
             exec_device "printf 'Package: *\nPin: release o=local\nPin-Priority: 2000\n\nPackage: *\nPin: release a=$SERIES*\nPin-Priority: 50' | SUDO_ASKPASS=/tmp/askpass.sh sudo -A tee /etc/apt/preferences.d/localrepo.pref"
 #            exec_device SUDO_ASKPASS=/tmp/askpass.sh sudo -A apt-get update
         else
+            rm -f $CREATE_REPO_SCRIPT
             exec_device /tmp/repo/$CREATE_REPO_SCRIPT /tmp/repo
         fi;
 

--- a/crossbuilder
+++ b/crossbuilder
@@ -93,11 +93,21 @@ push_device () {
 
 check_file_exists_device () {
     if ! adb pull "$1" /tmp 2>&1 >/dev/null ; then
+        # Some pull error, so we can assume, that the file doesn't exist.
         return 1
     fi
-
+    # Remove the pulled file.
     rm -f "/tmp/$(basename $1)"
     return 0
+}
+
+check_device_accessible () {
+    local DEVICE_STATE=$(adb get-state 2>/dev/null || true)
+    if [ "$DEVICE_STATE" = "device" ] ; then
+        # Device found
+        return 0
+    fi
+    return 1
 }
 
 exec_container_root () {
@@ -850,8 +860,7 @@ deploy_make_install () {
 }
 
 deploy_to_device () {
-    DEVICE_STATE=`adb get-state`
-    if [ "$DEVICE_STATE" != "device" ] ; then
+    if ! check_device_accessible ; then
         echo -e "${ERROR_COLOR}No device connected to deploy to.${NC}"
         exit 1
     fi;
@@ -1006,8 +1015,7 @@ DEVICE_PASSWORD=0000
 DEVICE_PASSWORD_FILE=~/.config/crossbuilder/device_password
 [ -e "$DEVICE_PASSWORD_FILE" ] && DEVICE_PASSWORD=$(cat $DEVICE_PASSWORD_FILE)
 
-DEVICE_STATE=`adb get-state || true`
-if [ "$DEVICE_STATE" = "device" ] ; then
+if check_device_accessible ; then
     DEVICE_ARCH=$(exec_device "dpkg --print-architecture" 2>&1 | tr -d '\r')
     if echo "$DEVICE_ARCH" | grep -vq "not found"; then
         TARGET_ARCH=$DEVICE_ARCH

--- a/crossbuilder
+++ b/crossbuilder
@@ -138,7 +138,8 @@ variables () {
     fi
     USERDIR=/home/$USERNAME
     SOURCE_REPOSITORY=$USERDIR/source_repository
-    SCRIPT_DIR=`dirname $0`
+    SCRIPT_REALPATH=$(realpath "${0}")
+    SCRIPT_DIR=$(dirname "${SCRIPT_REALPATH}")
     CREATE_REPO_SCRIPT=create_repository.sh
     MOUNTED_DIRECTORY=$PWD
     MOUNT_POINT=$USERDIR/$PACKAGE

--- a/crossbuilder
+++ b/crossbuilder
@@ -74,11 +74,11 @@ display_help () {
     echo "  --lxd-image      - LXD image to use [defaults to the ones provided by the Ubuntu SDK (example: ubuntu-sdk-16.04-amd64-armhf-dev)."
     echo "  --privileged     - Use a privileged container (disabled by default)."
     echo "  --ephemeral      - Build using a short-lived container (disabled by default)."
+    echo "  --ssh            - Use ssh with provided address instead of adb to deploy to device."
     echo "  --password       - User password of the device to deploy to [defaults to 0000]."
     echo "  --no-deb         - Do not build Debian packages and uses rsync to deploy the build artifacts."
     echo "  --deploy-path    - When deploying with --no-deb (rsync), installation path for the build artifacts [defaults to /]."
     echo "  --parallel       - Set parallelism of the build. Defaults to the number of logical core + 1."
-    echo "  --ssh            - Use ssh with provided address instead of adb."
 }
 
 
@@ -974,6 +974,9 @@ while [ "$1" != "" ]; do
             --lxd-image)
                 LXD_IMAGE=$VALUE
             ;;
+            --ssh)
+                SSH_ADDRESS=$VALUE
+            ;;
             --password)
                 DEVICE_PASSWORD=$VALUE
             ;;
@@ -992,9 +995,6 @@ while [ "$1" != "" ]; do
             ;;
             --parallel)
                 PARALLEL_BUILD=$VALUE
-            ;;
-            --ssh)
-                SSH_ADDRESS=$VALUE
             ;;
             --help)
                 display_help

--- a/crossbuilder
+++ b/crossbuilder
@@ -877,7 +877,13 @@ deploy_make_install () {
         DEPLOY_PATH="/"
     fi
 
-    sync_with_device $FOLDERS_TO_DEPLOY $DEPLOY_PATH
+    if [ ! -z "$SSH_ADDRESS" ]; then
+        # There is an ssh address already provided, skip sync_with_device script and just run the rsync.
+        rsync --rsync-path='SUDO_ASKPASS=/tmp/askpass.sh sudo -A rsync' -vae "ssh" $FOLDERS_TO_DEPLOY $SSH_ADDRESS:$DEPLOY_PATH
+        return
+    fi
+
+    . "$SCRIPT_DIR/sync_with_device" $FOLDERS_TO_DEPLOY $DEPLOY_PATH
 }
 
 deploy_to_device () {

--- a/crossbuilder
+++ b/crossbuilder
@@ -759,7 +759,7 @@ check_for_device_network() {
     NETWORK_UP=0
     for i in `seq 1 5`
     do
-        if adb shell ping -c1 -w1 google.com | grep PING > /dev/null 2>&1 ; then
+        if exec_device "ping -c1 -w1 google.com" | grep PING > /dev/null 2>&1 ; then
             NETWORK_UP=1
             break
         fi
@@ -801,7 +801,7 @@ deploy_deb () {
             exec_device "printf 'deb file:/tmp/repo/ /\n' > /tmp/repo/sources.list"
             exec_device "cp /etc/apt/sources.list /tmp/repo/all.list"
             exec_device "cat /tmp/repo/sources.list >> /tmp/repo/all.list"
-            SERIES=$(adb shell lsb_release -cs | tr -d '\r')
+            SERIES=$(exec_device "lsb_release -cs" | tr -d '\r')
             exec_device "printf 'Package: *\nPin: release o=local\nPin-Priority: 2000\n\nPackage: *\nPin: release a=$SERIES*\nPin-Priority: 50' | SUDO_ASKPASS=/tmp/askpass.sh sudo -A tee /etc/apt/preferences.d/localrepo.pref"
 #            exec_device SUDO_ASKPASS=/tmp/askpass.sh sudo -A apt-get update
         else
@@ -995,10 +995,10 @@ DEVICE_PASSWORD_FILE=~/.config/crossbuilder/device_password
 
 DEVICE_STATE=`adb get-state || true`
 if [ "$DEVICE_STATE" = "device" ] ; then
-    DEVICE_ARCH=$(adb shell "dpkg --print-architecture" 2>&1| tr -d '\r')
+    DEVICE_ARCH=$(exec_device "dpkg --print-architecture" 2>&1 | tr -d '\r')
     if echo "$DEVICE_ARCH" | grep -vq "not found"; then
         TARGET_ARCH=$DEVICE_ARCH
-        TARGET_UBUNTU=$(adb shell "lsb_release --release --short" | tr -d '\r')
+        TARGET_UBUNTU=$(exec_device "lsb_release --release --short" | tr -d '\r')
         DEPLOY=true
     fi
 fi;

--- a/crossbuilder
+++ b/crossbuilder
@@ -929,6 +929,72 @@ detect_host_architecture() {
     fi
 }
 
+while [ "$1" != "" ]; do
+    OPTION=`echo $1 | awk -F= '{print $1}'`
+    VALUE=`echo $1 | awk -F= '{print $2}'`
+    case $1 in
+        -*)
+            case $OPTION in
+            --packages)
+                PACKAGES_TO_DEPLOY=$VALUE
+            ;;
+            --architecture)
+                TARGET_ARCH=$VALUE
+            ;;
+            --ubuntu)
+                TARGET_UBUNTU=$VALUE
+            ;;
+            --lxd-image)
+                LXD_IMAGE=$VALUE
+            ;;
+            --password)
+                DEVICE_PASSWORD=$VALUE
+            ;;
+            --no-deb)
+                NO_DEB=1
+            ;;
+            --deploy-path)
+                DEPLOY_PATH=$VALUE
+            ;;
+            --privileged)
+                FORCE_PRIVILEGED=1
+            ;;
+            --ephemeral)
+                EPHEMERAL_CONTAINER=1
+                EPHEMERAL_FLAG=--ephemeral
+            ;;
+            --parallel)
+                PARALLEL_BUILD=$VALUE
+            ;;
+            --help)
+                display_help
+                exit 0
+            ;;
+            *)
+                display_help
+                echo ""
+                echo -e "${ERROR_COLOR}Error: unknown option: $OPTION${NC}"
+                exit 1
+            ;;
+            esac
+            shift
+        ;;
+        *)
+            break
+        ;;
+    esac
+done
+
+COMMAND=$1
+if [ -n "$COMMAND" ] ; then
+    shift
+fi
+
+if [ "$COMMAND" = "help" ] ; then
+    display_help
+    exit 0
+fi
+
 MISSING_PACKAGES=
 if ! which adb > /dev/null 2>&1 ; then
     if which apt > /dev/null 2>&1 ; then
@@ -1006,92 +1072,27 @@ if [ -z $HOST_ARCH ] ; then
     exit 1
 fi
 
-TARGET_ARCH=armhf
-TARGET_UBUNTU=16.04
+PARALLEL_BUILD=${PARALLEL_BUILD:-$((`nproc` + 1))}
 
-PARALLEL_BUILD=$((`nproc` + 1))
-
-DEVICE_PASSWORD=0000
 DEVICE_PASSWORD_FILE=~/.config/crossbuilder/device_password
-[ -e "$DEVICE_PASSWORD_FILE" ] && DEVICE_PASSWORD=$(cat $DEVICE_PASSWORD_FILE)
+if [ -z "$DEVICE_PASSWORD" ] ; then
+    [ -e "$DEVICE_PASSWORD_FILE" ] && DEVICE_PASSWORD=$(cat $DEVICE_PASSWORD_FILE) || DEVICE_PASSWORD=0000
+fi
 
 if check_device_accessible ; then
     DEVICE_ARCH=$(exec_device "dpkg --print-architecture" 2>&1 | tr -d '\r')
     if echo "$DEVICE_ARCH" | grep -vq "not found"; then
-        TARGET_ARCH=$DEVICE_ARCH
-        TARGET_UBUNTU=$(exec_device "lsb_release --release --short" | tr -d '\r')
+        DETECTED_TARGET_ARCH=$DEVICE_ARCH
+        DETECTED_TARGET_UBUNTU=$(exec_device "lsb_release --release --short" | tr -d '\r')
         DEPLOY=true
     fi
 fi;
 
-while [ "$1" != "" ]; do
-    OPTION=`echo $1 | awk -F= '{print $1}'`
-    VALUE=`echo $1 | awk -F= '{print $2}'`
-    case $1 in
-        -*)
-            case $OPTION in
-            --packages)
-                PACKAGES_TO_DEPLOY=$VALUE
-            ;;
-            --architecture)
-                TARGET_ARCH=$VALUE
-            ;;
-            --ubuntu)
-                TARGET_UBUNTU=$VALUE
-            ;;
-            --lxd-image)
-                LXD_IMAGE=$VALUE
-            ;;
-            --password)
-                DEVICE_PASSWORD=$VALUE
-            ;;
-            --no-deb)
-                NO_DEB=1
-            ;;
-            --deploy-path)
-                DEPLOY_PATH=$VALUE
-            ;;
-            --privileged)
-                FORCE_PRIVILEGED=1
-            ;;
-            --ephemeral)
-                EPHEMERAL_CONTAINER=1
-                EPHEMERAL_FLAG=--ephemeral
-            ;;
-            --parallel)
-                PARALLEL_BUILD=$VALUE
-            ;;
-            --help)
-                display_help
-                exit 0
-            ;;
-            *)
-                display_help
-                echo ""
-                echo -e "${ERROR_COLOR}error: unknown option: $OPTION${NC}"
-                exit 1
-            ;;
-            esac
-            shift
-        ;;
-        *)
-            break
-        ;;
-    esac
-done
+TARGET_ARCH="${TARGET_ARCH:-${DETECTED_TARGET_ARCH:-armhf}}"
+TARGET_UBUNTU="${TARGET_UBUNTU:-${DETECTED_TARGET_UBUNTU:-16.04}}"
 
 if [ -z "$LXD_IMAGE" ] ; then
     LXD_IMAGE=ubports-sdk:ubuntu-sdk-$TARGET_UBUNTU-$HOST_ARCH-$TARGET_ARCH-dev
-fi
-
-COMMAND=$1
-if [ -n "$COMMAND" ] ; then
-    shift
-fi
-
-if [ "$COMMAND" = "help" ] ; then
-    display_help
-    exit 0
 fi
 
 check_command_parameter_count () {


### PR DESCRIPTION
This PR adds the ability to deploy via ssh.

I've splitted the PR into thematic commits for easier review.
- The first 6 commits (28a4ea0, ..., 7e1fd88) are refactoring changes, which moves all the ```adb``` commands in crossbuilder script into functions with a concrete goal (exec_device, push_device, ...), one ```adb``` type per commit.
- The 7th commit (9eddcb7) refactors the options parameter evaluation before the first ```adb``` command call (missing packages checks), to be able to not use adb if --ssh option is passed.
- The 8th commit (f27805e) is the actual ssh code logic.
- The last 2 commits (6c1dd34, 4ea693c) are documentation updates and a fix to be able to use --ssh with --no-deb option.

Note: This solves #42 and #14 and renders some changes as unnecessary in PR #53.