### PR TITLE
replace google.com with ubports.com for pinging

### DIFF
--- a/crossbuilder
+++ b/crossbuilder
@@ -825,7 +825,7 @@ check_for_device_network() {
     NETWORK_UP=0
     for i in `seq 1 5`
     do
-        if device exec "ping -c1 -w1 google.com" | grep PING > /dev/null 2>&1 ; then
+        if device exec "ping -c1 -w1 ubports.com" | grep PING > /dev/null 2>&1 ; then
             NETWORK_UP=1
             break
         fi


### PR DESCRIPTION
At some point the crossbuilder script does a ping to see if the connected device has got a working internet connection. Why does it need to ping google.com and link all out devices to google? I suggest using ubports.com, of any other privacy friendly solution. Suggestions welcome.