### PR TITLE
Bump version with +1 in front

### DIFF
--- a/crossbuilder
+++ b/crossbuilder
@@ -158,7 +158,7 @@ exec_container () {
 variables () {
     DEBS_TARBALL_ROOT=debs
     if [ -n "$NEW_BUILD" ] ; then
-        NEW_PACKAGE_VERSION=$PACKAGE_VERSION"local~"`date +%s`
+        NEW_PACKAGE_VERSION=$PACKAGE_VERSION"+1local~"`date +%s`
     else
         LATEST_DEBS_TARBALL=$(ls -1 --sort=time $DEBS_TARBALL_ROOT_*.tar 2> /dev/null | head -n1)
         NEW_PACKAGE_VERSION=$(echo $LATEST_DEBS_TARBALL | sed "s/$DEBS_TARBALL_ROOT\_//" | sed "s/\.tar//")


### PR DESCRIPTION
Due to the way our CI works, the version in the changelog will usually be bumped with `+0`. So, to combat with that, bump ours to `+1`.

This is particularly important when working with a library. When other packages are built against this one, dpkg-shlibdeps embeds the version of this package as seen in the CI. If we don't get this package's version to be higher, apt will start removing those packages installed on the phone.