### PR TITLE
Allow forcing packages from current build

### DIFF
--- a/crossbuilder
+++ b/crossbuilder
@@ -887,7 +887,7 @@ deploy_deb () {
 
         device exec "SUDO_ASKPASS=/tmp/askpass.sh sudo -A sed -i '/Pin-Priority/c\Pin-Priority: 50' /etc/apt/preferences.d/extra-ppas.pref"
         device exec SUDO_ASKPASS=/tmp/askpass.sh sudo -A  apt-get update -o Dir::Etc::sourcelist="/tmp/repo/sources.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
-        device exec SUDO_ASKPASS=/tmp/askpass.sh sudo -A apt-get dist-upgrade -o Dir::Etc::sourcelist="/tmp/repo/all.list" --yes --force-yes
+        device exec SUDO_ASKPASS=/tmp/askpass.sh sudo -A apt-get dist-upgrade -o Dir::Etc::sourcelist="/tmp/repo/all.list" --yes --allow-change-held-packages -f
         device exec "SUDO_ASKPASS=/tmp/askpass.sh sudo -A sed -i '/Pin-Priority/c\Pin-Priority: 1001' /etc/apt/preferences.d/extra-ppas.pref"
     fi;
 }


### PR DESCRIPTION
1. fixing error `--force-yes is deprecated, use one of the options starting with --allow instead`

2. when building lomiri-system-settings and deploing locally, apt is ignoring the local version (e.g. 1.0.2+1local~1725113893) and wanting the repository version (e.g. 1.0.2+0~20240710053303.1+ubports20.04~1.gbp001aac) this change is forcing the local version  https://forums.ubports.com/topic/9536/error-while-installing-lomiri-systems-settings